### PR TITLE
Add event to log unhandled Promise rejections

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,3 +215,8 @@ var getClientIpAddress = function (input) {
 
   return result.trim();
 };
+
+// Catch possibly unhandled rejections
+process.on('unhandledRejection', function (reason, p) {
+  self.error(reason);
+});


### PR DESCRIPTION
As we move to using Promises for our asynchronous logic across the board in our core platform products, we need to make sure the errors they generate are properly caught and handled.

A Promise chain without a `catch()` will swallow any errors generated, making the debugging process extremely difficult.

The code below will not produce any errors in the console because there is no `catch()` in the chain.

``` js
var result = somePromise()
              .then(function () {
                // This will throw an error
                functionThatDoesNotExist();
              });
```

---

This PR adds a listener to the `unhandledRejection` event, which will fire when a possibly unhandled exception is detected, issuing a `log.error()` . I think this will prove extremely useful not only in development, but also in production environments.

I think it makes sense to add it to the logger piece since it's being used by most of our products, but if you think it should exist individually in each product's codebase, I'm happy to do it that way.

cc @jimlambie @mingard 
