### PR TITLE
fix: only write to access log if configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DADI Logger
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/logger.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/logger)
-[![coverage](https://img.shields.io/badge/coverage-70%25-yellow.svg?style=flat-square)](https://github.com/dadi/logger)
+[![coverage](https://img.shields.io/badge/coverage-73%25-yellow.svg?style=flat-square)](https://github.com/dadi/logger)
 [![Build Status](https://travis-ci.org/dadi/logger.svg?branch=master)](https://travis-ci.org/dadi/logger)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 

--- a/dadi/index.js
+++ b/dadi/index.js
@@ -134,7 +134,7 @@ var self = module.exports = {
   },
 
   access: function access () {
-    if (this.options.accessLog.enabled) {
+    if (this.options.accessLog && this.options.accessLog.enabled) {
       try {
         accessLog.info.apply(accessLog, arguments)
       } catch (err) {


### PR DESCRIPTION
If no accessLog property is passed in config, assume access logging is disabled

Fix #36 