### PR TITLE
feat: streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DADI Logger
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/logger.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/logger)
-[![coverage](https://img.shields.io/badge/coverage-72%25-yellow.svg?style=flat-square)](https://github.com/dadi/logger)
+[![coverage](https://img.shields.io/badge/coverage-72%2525-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/logger)
 [![Build Status](https://travis-ci.org/dadi/logger.svg?branch=master)](https://travis-ci.org/dadi/logger)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)
@@ -34,6 +34,7 @@ Property|Description|Default|Example
 --------|-----------|-------|-------
 enabled|If true, logging is enabled using the following settings|false|true
 level|The threshold for writing to the log. Levels: `debug`, `info`, `warn`, `error`, `trace` |"info"|"warn"
+stream|The stream instance to write the log to||`process.stdout`
 path|The absolute or relative path to the directory for log files|"./log"|"/var/log/"
 filename|The filename to use for logs, without extension| |"web"
 extension|The file extension to use for logs|".log"|".txt"

--- a/dadi/index.js
+++ b/dadi/index.js
@@ -58,6 +58,17 @@ function setOptions (options, awsConfig, environment) {
 }
 
 function getStreams (options) {
+  if (options.stream && options.stream.enabled) {
+    const level = options.level || 'error'
+
+    if (options.instance) {
+      return [{
+        level,
+        stream: options.instance
+      }]
+    }
+  }
+
   if (options.testStream) { // override for testing
     return options.testStream
   }

--- a/dadi/index.js
+++ b/dadi/index.js
@@ -67,6 +67,13 @@ function getStreams (options) {
         stream: options.instance
       }]
     }
+
+    if (options.library) {
+      const streamLibrary = options.library
+      const streamOptions = options.stream.options || undefined
+      const stream = new streamLibrary(streamOptions)
+      return [{ level, stream }]
+    }
   }
 
   if (options.testStream) { // override for testing

--- a/dadi/index.js
+++ b/dadi/index.js
@@ -69,9 +69,9 @@ function getStreams (options) {
     }
 
     if (options.stream.library) {
-      const streamLibrary = options.stream.library
+      const StreamLibrary = options.stream.library
       const streamOptions = options.stream.options || undefined
-      const stream = new streamLibrary(streamOptions)
+      const stream = new StreamLibrary(streamOptions)
       return [{ level, stream }]
     }
   }

--- a/dadi/index.js
+++ b/dadi/index.js
@@ -60,10 +60,10 @@ function setOptions (options, awsConfig, environment) {
 function getStreams (options, defaultLevel) {
   const level = options.level || defaultLevel || 'error'
   const streamInstance = getStreamInstance(options, level)
-  const streamLibraryInstance = getStreamLibraryInstance(options, level)
 
-  if (streamInstance) return streamInstance
-  if (streamLibraryInstance) return streamLibraryInstance
+  if (streamInstance) {
+    return streamInstance
+  }
 
   if (defaultLevel === 'access') {
     return [{
@@ -79,20 +79,11 @@ function getStreams (options, defaultLevel) {
 }
 
 function getStreamInstance (options, level) {
-  if (options.stream && options.stream.instance) {
+  if (options.stream && typeof options.stream === 'object') {
     return [{
       level,
-      stream: options.stream.instance
+      stream: options.stream
     }]
-  }
-}
-
-function getStreamLibraryInstance (options, level) {
-  if (options.stream && options.stream.library) {
-    const StreamLibrary = options.stream.library
-    const streamOptions = options.stream.options || undefined
-    const stream = new StreamLibrary(streamOptions)
-    return [{ level, stream }]
   }
 }
 

--- a/dadi/index.js
+++ b/dadi/index.js
@@ -61,15 +61,15 @@ function getStreams (options) {
   if (options.stream && options.stream.enabled) {
     const level = options.level || 'error'
 
-    if (options.instance) {
+    if (options.stream.instance) {
       return [{
         level,
-        stream: options.instance
+        stream: options.stream.instance
       }]
     }
 
-    if (options.library) {
-      const streamLibrary = options.library
+    if (options.stream.library) {
+      const streamLibrary = options.stream.library
       const streamOptions = options.stream.options || undefined
       const stream = new streamLibrary(streamOptions)
       return [{ level, stream }]

--- a/test/requestLogger.js
+++ b/test/requestLogger.js
@@ -47,9 +47,7 @@ describe('Request Logger', function () {
     filename: 'test',
     level: 'trace',
     path: 'log/',
-    stream: {
-      instance: memstream
-    }
+    stream: memstream
   }, null, 'test')
 
   it('should log a request', function (done) {

--- a/test/requestLogger.js
+++ b/test/requestLogger.js
@@ -47,7 +47,9 @@ describe('Request Logger', function () {
     filename: 'test',
     level: 'trace',
     path: 'log/',
-    testStream: [{level: 'trace', stream: memstream}]
+    stream: {
+      instance: memstream
+    }
   }, null, 'test')
 
   it('should log a request', function (done) {

--- a/test/standardLogger.js
+++ b/test/standardLogger.js
@@ -15,7 +15,9 @@ describe('Standard Logger', function () {
     filename: 'test',
     level: 'trace',
     path: 'log/',
-    testStream: [{level: 'trace', stream: memstream}]
+    stream: {
+      instance: memstream
+    }
   }, null, 'test')
 
   it('should log at the trace level', function (done) {

--- a/test/standardLogger.js
+++ b/test/standardLogger.js
@@ -15,9 +15,7 @@ describe('Standard Logger', function () {
     filename: 'test',
     level: 'trace',
     path: 'log/',
-    stream: {
-      instance: memstream
-    }
+    stream: memstream
   }, null, 'test')
 
   it('should log at the trace level', function (done) {

--- a/test/streamInstance.js
+++ b/test/streamInstance.js
@@ -1,0 +1,30 @@
+var assert = require('chai').assert
+var memoryStream = require('memorystream')
+
+describe('Stream Instance', function () {
+  // our logger is a singleton, but we need a clean instance
+  delete require.cache[require.resolve('./../dadi/index.js')]
+  var logger = require('./../dadi/index.js')
+  var memstream = new memoryStream()
+  
+  logger.init({
+    accessLog: {
+      enabled: false // no access log, only expecting single messages
+    },
+    enabled: true,
+    filename: 'test',
+    level: 'info',
+    path: 'log/',
+    stream: memstream
+  }, null, 'test')
+  
+  it('should log to the provided stream instance', function (done) {
+    memstream.once('data', function (chunk) {
+      var output = JSON.parse(chunk.toString())
+      assert(output.msg === 'test')
+      done()
+    })
+
+    logger.info('test')
+  })
+})


### PR DESCRIPTION
This PR allows the use of streams, either [configurable libraries](https://github.com/trentm/node-bunyan/wiki/Awesome-Bunyan#streams) or stream instances, such as `process.stdout`.

Closes #50 

## Usage 

```
const logger = require('@dadi/logger')

const options = {
  enabled: true,
  level: 'info',
  stream: {
    enabled: true,
    instance: process.stdout
  }
}

logger.init(options, {}, process.env.NODE_ENV)
logger.info({ module: 'ImageHandler' }, 'GET: ' + req.url)
```